### PR TITLE
Allow storing attachment binary data within the clixml file

### DIFF
--- a/MailDaemon/functions/Invoke-MDDaemon.ps1
+++ b/MailDaemon/functions/Invoke-MDDaemon.ps1
@@ -53,8 +53,10 @@
 			if ($email.From) { $parameters["From"] = $email.From }
 			else { $parameters["From"] = Get-PSFConfigValue -FullName 'MailDaemon.Daemon.SenderDefault' }
 			if ($email.Cc) { $parameters["Cc"] = $email.Cc }
+			if ($email.Bcc) { $parameters["Bcc"] = $email.Bcc }
 			if ($email.Subject) { $parameters["Subject"] = $email.Subject }
 			else { $parameters["Subject"] = "<no subject>" }
+			if ($email.Priority) {$parameters["Priority"] = $email.Priority}
 			if ($email.Body) { $parameters["Body"] = $email.Body }
 			if ($null -ne $email.BodyAsHtml) { $parameters["BodyAsHtml"] = $email.BodyAsHtml }
 			if ($email.Attachments) {

--- a/MailDaemon/functions/Invoke-MDDaemon.ps1
+++ b/MailDaemon/functions/Invoke-MDDaemon.ps1
@@ -36,7 +36,7 @@
 	process
 	{
 		#region Send mails
-		foreach ($item in (Get-ChildItem -Path (Get-PSFConfigValue -FullName 'MailDaemon.Daemon.MailPickupPath')))
+		foreach ($item in (Get-ChildItem -Path (Get-PSFConfigValue -FullName 'MailDaemon.Daemon.MailPickupPath') -Filter "*.clixml"))
 		{
 			$email = Import-Clixml -Path $item.FullName
 			# Skip emails that should not yet be processed
@@ -57,7 +57,23 @@
 			else { $parameters["Subject"] = "<no subject>" }
 			if ($email.Body) { $parameters["Body"] = $email.Body }
 			if ($null -ne $email.BodyAsHtml) { $parameters["BodyAsHtml"] = $email.BodyAsHtml }
-			if ($email.Attachments) { $parameters["Attachments"] = $email.Attachments }
+			if ($email.Attachments) {
+			    if ($email.AttachmentsBinary) {
+			        $tempAttachmentParentDir = New-Item (join-path $item.Directory $item.BaseName) -Force -ItemType Directory
+			        $attachmentCounter = 0
+			        $parameters["Attachments"] = @()
+			        # Using multiple subfolders to allow for duplicate attachment names
+			        foreach ($binaryAttachment in $email.AttachmentsBinary) {
+			            $tempAttachmentDir = new-item (join-path $tempAttachmentParentDir $attachmentCounter) -Force -ItemType Directory
+			            $tempAttachmentPath = join-path $tempAttachmentDir $binaryAttachment.Name
+			            $null = [System.IO.File]::WriteAllBytes($tempAttachmentPath, $binaryAttachment.Data)
+			            $parameters["Attachments"] = @($parameters["Attachments"]) + $tempAttachmentPath
+			            $attachmentCounter = $attachmentCounter + 1
+			        }
+			    } else {
+                    $parameters["Attachments"] = $email.Attachments
+			    }
+            }
 			if ($script:_Config.SenderCredentialPath) { $parameters["Credential"] = Import-Clixml (Get-PSFConfigValue -FullName 'MailDaemon.Daemon.SenderCredentialPath') }
 			
 			Write-PSFMessage -Level Verbose -String 'Invoke-MDDaemon.SendMail.Start' -StringValues @($email.Taskname, $parameters['Subject'], $parameters['From'], ($parameters['To'] -join ",")) -Target $email.Taskname
@@ -73,6 +89,10 @@
 					Remove-Item $attachment -Force
 				}
 			}
+			# Remove temp deserialized attachments if used 
+            if ($email.AttachmentsBinary) {
+                $null = remove-item -Path $tempAttachmentParentDir -Recurse -Force
+            }
 
 			# Update the timestamp (the timeout for deletion uses this) and move it to the sent items folder
 			$item.LastWriteTime = Get-Date

--- a/MailDaemon/functions/Set-MDMail.ps1
+++ b/MailDaemon/functions/Set-MDMail.ps1
@@ -1,4 +1,10 @@
-﻿function Set-MDMail
+﻿enum MailPriority {
+    Normal
+    Low
+    High
+}
+
+function Set-MDMail
 {
 	<#
 		.SYNOPSIS
@@ -49,12 +55,15 @@
 		[string]
 		$From,
 
-		[string]
+		[string[]]
 		$To,
 
 		[string[]]
 		$Cc,
 
+		[string[]]
+		$Bcc,
+		
 		[string]
 		$Subject,
 
@@ -64,14 +73,17 @@
 		[switch]
 		$BodyAsHtml,
 
-		[string]
+		[string[]]
 		$Attachments,
 
 		[switch]
 		$RemoveAttachments,
 
 		[datetime]
-		$NotBefore
+		$NotBefore, 
+		
+		[MailPriority]
+		$Priority
 	)
 	
 	begin
@@ -86,11 +98,13 @@
 		if ($From) { $script:mail["From"] = $From }
 		if ($To) { $script:mail["To"] = $To }
 		if ($Cc) { $script:mail["Cc"] = $Cc }
+		if ($Bcc) { $script:mail["Bcc"] = $Bcc }
 		if ($Subject) { $script:mail["Subject"] = $Subject }
 		if ($Body) { $script:mail["Body"] = $Body }
 		if ($BodyAsHtml.IsPresent) { $script:mail["BodyAsHtml"] = ([bool]$BodyAsHtml) }
 		if ($Attachments) { $script:mail["Attachments"] = $Attachments }
 		if ($RemoveAttachments.IsPresent) { $script:mail["RemoveAttachments"] = ([bool]$RemoveAttachments) }
 		if ($NotBefore) { $script:mail["NotBefore"] = $NotBefore }
+		if ($Priority) { $script:mail["Priority"] = $Priority }
 	}
 }


### PR DESCRIPTION
Occasionally I have scripts that generate an attachment and send an email within a loop. The current MailDaemon approach of storing the path with the email object would result in the final attachment being used for all emails when sent. 

These changes add a -PersistAttachments switch to Send-MDMail which serializes the attachment binary into the clixml file.